### PR TITLE
loadLibrary fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>graphics.scenery</groupId>
     <artifactId>spirvcrossj</artifactId>
-    <version>0.6.0-1.1.106.0</version>
+    <version>0.7.0-1.1.106.0</version>
     <inceptionYear>2016</inceptionYear>
 
     <name>spirvcrossj</name>

--- a/src/main/java/graphics/scenery/spirvcrossj/Loader.java
+++ b/src/main/java/graphics/scenery/spirvcrossj/Loader.java
@@ -193,20 +193,18 @@ public class Loader {
             }
         }
 
-        lp = System.getProperty("java.library.path");
-        System.setProperty("java.library.path", lp + File.pathSeparator + new java.io.File( "." ).getCanonicalPath() + File.separator + "target" + File.separator + "classes");
+        String libraryPath = new java.io.File( "." ).getCanonicalPath()
+                + File.separator + "target"
+                + File.separator + "classes"
+                + File.separator + libraryName;
 
-        try {
-            Field fieldSysPath = ClassLoader.class.getDeclaredField("sys_paths");
-            fieldSysPath.setAccessible(true);
-            fieldSysPath.set(null, null);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            System.err.println("Failed to set java.library.path: " + e.getMessage());
-            e.printStackTrace();
+        // we try local path first, in case we're running on the CI
+        if(!new File(libraryPath).exists()) {
+            libraryPath = tmpDir + File.separator + libraryName;
         }
 
         try {
-            System.loadLibrary("spirvcrossj");
+            System.load(libraryPath);
         } catch (UnsatisfiedLinkError e) {
             System.err.println("Unable to load native library: " + e.getMessage());
             String osname = System.getProperty("os.name");


### PR DESCRIPTION
This PR exchanges System.loadLibrary (and associated messing with sys_paths) for the more standard-conformant System.load(). That fixes #21 and #19. In addition, it fixes #20.