### PR TITLE
Point scm to github source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <connection>scm:git:git://github.com/skalarproduktraum/spirvcrossj</connection>
         <developerConnection>scm:git:git@github.com:skalarproduktraum/spirvcrossj</developerConnection>
         <tag>HEAD</tag>
-        <url>http://scenery.graphics</url>
+        <url>https://github.com/scenerygraphics/spirvcrossj</url>
     </scm>
     <issueManagement>
         <system>GitHub</system>


### PR DESCRIPTION
This allows the url to be scraped for automation tasks, i.e. the melting
pot.